### PR TITLE
Add model number explainer demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Codex_Playground
-A playground for OpenAI's Codex
+
+This repository contains small experiments and demos for the Codex environment.
+
+## Model Number Explainer
+
+Open `index.html` in a browser to see a demo that explains TV model numbers. The page splits the model number into parts and shows lines connecting each part to its description. Hovering a part highlights it and its explanation.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Model Number Explainer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="input-area">
+    <label for="model">Model number:</label>
+    <input id="model" value="MG65V24USBT2/14" />
+    <button id="explain-btn">Explain</button>
+  </div>
+  <div id="canvas">
+    <pre id="command"></pre>
+    <svg id="lines"></svg>
+    <div id="explanations"></div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,82 @@
+const database = {
+  'MG': 'Prefix of our company, Magic World',
+  '65': 'Is the size in inches',
+  'V': 'Means the TV is part of the V-Series',
+  '24': 'Refers to the "Frameless" feature',
+  'U': 'Refers to the 4K UHD resolution',
+  'S': 'Refers to the "Smart" feature',
+  'B': 'Unassigned',
+  'T2': 'Means the TV has a built-in DVB-S2/T2 receiver',
+  '14': 'Refers to the OS, being Android 14'
+};
+
+function explain(model) {
+  const command = document.getElementById('command');
+  const explanations = document.getElementById('explanations');
+  const linesSvg = document.getElementById('lines');
+
+  command.innerHTML = '';
+  explanations.innerHTML = '';
+  linesSvg.innerHTML = '';
+
+  const parts = model.replace(/\//g, ' ').match(/[A-Za-z]+\d+|\d+|[A-Za-z]+/g) || [];
+  const spans = [];
+  parts.forEach((part, idx) => {
+    const span = document.createElement('span');
+    span.textContent = part;
+    span.dataset.index = idx;
+    span.className = 'token';
+    command.appendChild(span);
+    command.appendChild(document.createTextNode(' '));
+
+    const box = document.createElement('div');
+    box.className = 'explanation';
+    box.textContent = database[part] || 'Unknown segment';
+    box.dataset.index = idx;
+    explanations.appendChild(box);
+    spans.push({span, box});
+  });
+
+  // draw lines
+  spans.forEach(({span, box}, idx) => {
+    const spanRect = span.getBoundingClientRect();
+    const boxRect = box.getBoundingClientRect();
+    const containerRect = command.getBoundingClientRect();
+
+    const x1 = spanRect.left + spanRect.width / 2 - containerRect.left;
+    const y1 = spanRect.bottom - containerRect.top;
+    const x2 = boxRect.left - containerRect.left - 5; // left of explanation
+    const y2 = boxRect.top + boxRect.height / 2 - containerRect.top;
+
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', `M${x1},${y1} L${x1 + 20},${y1} L${x2 - 20},${y2} L${x2},${y2}`);
+    path.setAttribute('stroke', `hsl(${idx * 40},70%,50%)`);
+    linesSvg.appendChild(path);
+  });
+
+  // interactive highlight
+  spans.forEach(({span, box}) => {
+    span.addEventListener('mouseover', () => highlight(span, box, true));
+    span.addEventListener('mouseout', () => highlight(span, box, false));
+    box.addEventListener('mouseover', () => highlight(span, box, true));
+    box.addEventListener('mouseout', () => highlight(span, box, false));
+  });
+}
+
+function highlight(span, box, on) {
+  if (on) {
+    span.classList.add('active');
+    box.classList.add('active');
+  } else {
+    span.classList.remove('active');
+    box.classList.remove('active');
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('explain-btn').addEventListener('click', () => {
+    const model = document.getElementById('model').value.trim();
+    explain(model);
+  });
+  explain(document.getElementById('model').value.trim());
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,64 @@
+body {
+  font-family: sans-serif;
+  margin: 20px;
+}
+
+#input-area {
+  margin-bottom: 1em;
+}
+
+#canvas {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+}
+
+#command {
+  margin: 0;
+  font-size: 18px;
+  background: #f7f7f7;
+  padding: 10px;
+  border-radius: 4px;
+}
+
+#command span {
+  padding: 3px 4px;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+#command span:hover,
+#command span.active {
+  background-color: #ffe58f;
+}
+
+#explanations {
+  margin-left: 20px;
+  position: relative;
+}
+
+.explanation {
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 6px 10px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+  position: relative;
+}
+
+.explanation:hover,
+.explanation.active {
+  background-color: #e6f7ff;
+}
+
+svg#lines {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+}
+
+#lines path {
+  stroke-width: 2;
+  fill: none;
+}


### PR DESCRIPTION
## Summary
- demonstrate explaining TV model numbers
- show tokens connected with lines to their explanations
- basic hover highlighting

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6846f0a797208322a57464adf5721400