### PR TITLE
Improve connector layout and styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,7 +19,9 @@ function explain(model) {
   explanations.innerHTML = '';
   linesSvg.innerHTML = '';
 
-  const parts = model.replace(/\//g, ' ').match(/[A-Za-z]+\d+|\d+|[A-Za-z]+/g) || [];
+  const parts = model
+    .replace(/\//g, ' ')
+    .match(/[A-Za-z]+\d+|\d+|[A-Za-z]+/g) || [];
   const spans = [];
   parts.forEach((part, idx) => {
     const span = document.createElement('span');
@@ -38,11 +40,26 @@ function explain(model) {
   });
 
 
-  spans.forEach(({span, box}, idx) => {
+  // draw connector lines with 90-degree bends
+  const containerRect = document.getElementById('canvas').getBoundingClientRect();
+  linesSvg.setAttribute('width', containerRect.width);
+  linesSvg.setAttribute('height', containerRect.height);
+
+  spans.forEach(({ span, box }, idx) => {
     const spanRect = span.getBoundingClientRect();
     const boxRect = box.getBoundingClientRect();
-    const containerRect = command.getBoundingClientRect();
 
+    const startX = spanRect.right - containerRect.left;
+    const startY = spanRect.top + spanRect.height / 2 - containerRect.top;
+    const endX = boxRect.left - containerRect.left;
+    const endY = boxRect.top + boxRect.height / 2 - containerRect.top;
+
+    const midX = startX + 40 + idx * 20;
+
+    const d = `M ${startX} ${startY} L ${midX} ${startY} L ${midX} ${endY} L ${endX} ${endY}`;
+
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', d);
     path.setAttribute('stroke', `hsl(${idx * 40},70%,50%)`);
     linesSvg.appendChild(path);
   });

--- a/style.css
+++ b/style.css
@@ -1,5 +1,7 @@
 body {
-
+  font-family: Arial, sans-serif;
+  background: #f0f0f0;
+  padding: 20px;
 }
 
 #input-area {
@@ -10,31 +12,43 @@ body {
   position: relative;
   display: flex;
   align-items: flex-start;
+  padding: 20px;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 #command {
   margin: 0;
   font-size: 18px;
-  background: #f7f7f7;
+  background: #2d2d2d;
+  color: #f8f8f2;
   padding: 10px;
   border-radius: 4px;
+  font-family: monospace;
 }
 
 #command span {
   padding: 3px 4px;
   cursor: pointer;
   border-radius: 3px;
-
+  background: #444;
+  color: #fff;
+  margin-right: 2px;
 }
 
 #command span:hover,
 #command span.active {
-
+  background: #fffb91;
+  color: #000;
 }
 
 #explanations {
   margin-left: 20px;
   position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
 .explanation {
@@ -44,7 +58,8 @@ body {
   border-radius: 4px;
   margin-bottom: 8px;
   position: relative;
-
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  width: 260px;
 }
 
 .explanation:hover,


### PR DESCRIPTION
## Summary
- render explanation lines with 90° bends and avoid overlap by offsetting each path
- visually stack explanation boxes with explainshell.com inspired styling
- add dark command styling and general UI enhancements

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6847018a964c832299c353df5c228003