### PR TITLE
Fix explanation layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -49,14 +49,14 @@ function explain(model) {
     const spanRect = span.getBoundingClientRect();
     const boxRect = box.getBoundingClientRect();
 
-    const startX = spanRect.right - containerRect.left;
-    const startY = spanRect.top + spanRect.height / 2 - containerRect.top;
+    const startX = spanRect.left + spanRect.width / 2 - containerRect.left;
+    const startY = spanRect.bottom - containerRect.top;
     const endX = boxRect.left - containerRect.left;
     const endY = boxRect.top + boxRect.height / 2 - containerRect.top;
 
-    const midX = startX + 40 + idx * 20;
+    const midY = startY + 20 + idx * 20;
 
-    const d = `M ${startX} ${startY} L ${midX} ${startY} L ${midX} ${endY} L ${endX} ${endY}`;
+    const d = `M ${startX} ${startY} L ${startX} ${midY} L ${endX} ${midY} L ${endX} ${endY}`;
 
     const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
     path.setAttribute('d', d);

--- a/style.css
+++ b/style.css
@@ -10,8 +10,6 @@ body {
 
 #canvas {
   position: relative;
-  display: flex;
-  align-items: flex-start;
   padding: 20px;
   background: #fff;
   border: 1px solid #ddd;
@@ -45,10 +43,11 @@ body {
 }
 
 #explanations {
-  margin-left: 20px;
+  margin-top: 20px;
   position: relative;
   display: flex;
   flex-direction: column;
+  width: 100%;
 }
 
 .explanation {
@@ -59,7 +58,8 @@ body {
   margin-bottom: 8px;
   position: relative;
   box-shadow: 0 1px 3px rgba(0,0,0,0.08);
-  width: 260px;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .explanation:hover,


### PR DESCRIPTION
## Summary
- adjust canvas styling to stack output under the input
- make explanation container full width and fit boxes
- redraw connector lines vertically from tokens to explanations

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68470d56339883228bb4f3942c0b2526