### PR TITLE
Adjust width and connector paths

### DIFF
--- a/script.js
+++ b/script.js
@@ -39,11 +39,22 @@ function explain(model) {
     spans.push({span, box});
   });
 
-
-  // draw connector lines with 90-degree bends
+  // adjust widths
   const canvasEl = document.getElementById('canvas');
   const containerRect = canvasEl.getBoundingClientRect();
+  const halfWidth = containerRect.width / 2;
+  command.style.width = 'auto';
+  const contentWidth = command.scrollWidth;
+  const targetWidth = contentWidth > halfWidth ? contentWidth + 20 : halfWidth;
+  command.style.width = `${targetWidth}px`;
+  document.querySelectorAll('.explanation').forEach((box) => {
+    box.style.width = `${targetWidth}px`;
+  });
+
+  // draw connector lines with 90-degree bends
   const leftPad = parseFloat(getComputedStyle(canvasEl).paddingLeft) || 0;
+  const rightPad = parseFloat(getComputedStyle(canvasEl).paddingRight) || 0;
+  const innerWidth = containerRect.width - leftPad - rightPad;
   linesSvg.setAttribute('width', containerRect.width);
   linesSvg.setAttribute('height', containerRect.height);
 
@@ -53,11 +64,14 @@ function explain(model) {
 
     const startX = spanRect.left + spanRect.width / 2 - containerRect.left - leftPad;
     const startY = spanRect.bottom - containerRect.top;
-    const endX = boxRect.left - containerRect.left - leftPad;
     const endY = boxRect.top + boxRect.height / 2 - containerRect.top;
-
-    const laneX = endX - 20 - idx * 20;   // lane positioned left of the box
-    const midY = startY + 20 + idx * 20;
+    const attachLeft = idx % 2 === 0;
+    const endX = attachLeft
+      ? boxRect.left - containerRect.left - leftPad
+      : boxRect.right - containerRect.left - leftPad;
+    const laneBase = attachLeft ? -leftPad / 2 : innerWidth + rightPad / 2;
+    const laneX = attachLeft ? laneBase - idx * 10 : laneBase + idx * 10;
+    const midY = startY + 30 + idx * 20;
 
     const d =
       `M ${startX} ${startY}` +

--- a/style.css
+++ b/style.css
@@ -10,7 +10,7 @@ body {
 
 #canvas {
   position: relative;
-  padding: 20px 20px 20px 80px; /* space for connector lane */
+  padding: 20px 80px; /* space for connector lanes on both sides */
   background: #fff;
   border: 1px solid #ddd;
   border-radius: 6px;
@@ -25,6 +25,9 @@ body {
   padding: 10px;
   border-radius: 4px;
   font-family: monospace;
+  display: inline-block;
+  max-width: 50%;
+  width: auto;
 }
 
 #command span {
@@ -43,12 +46,12 @@ body {
 }
 
 #explanations {
-  margin-top: 20px;
+  margin-top: 40px;
   position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding-left: 80px; /* lane area */
+  padding: 0 80px; /* lane areas on both sides */
 }
 
 .explanation {
@@ -59,7 +62,8 @@ body {
   margin-bottom: 8px;
   position: relative;
   box-shadow: 0 1px 3px rgba(0,0,0,0.08);
-  width: 100%;
+  width: auto;
+  max-width: 50%;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- narrow the command and explanation containers
- add extra padding on both sides of canvas for routing
- adjust connector routes to alternate left/right
- size boxes based on model length

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847ebc5d794832296a37a8e061e61f0